### PR TITLE
Update n!n overlay to new pinctrl definition

### DIFF
--- a/config/boards/shields/ffkb/boards/nice_nano_v2.overlay
+++ b/config/boards/shields/ffkb/boards/nice_nano_v2.overlay
@@ -1,13 +1,50 @@
 #include <dt-bindings/led/led.h>
 
+&pinctrl {
+    spi0_default: spi0_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 10)
+                     NRF_PSEL(SPIM_SCK, 1, 13)
+                     NRF_PSEL(SPIM_MISO, 1, 11)>;
+        };
+    };
+
+    spi0_sleep: spi0_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 10)
+                     NRF_PSEL(SPIM_SCK, 1, 13)
+                     NRF_PSEL(SPIM_MISO, 1, 11)>;
+            low-power-enable;
+        };
+    };
+
+    spi1_default: spi1_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)
+                     NRF_PSEL(SPIM_SCK, 0, 5)
+                     NRF_PSEL(SPIM_MISO, 0, 7)>;
+        };
+    };
+
+    spi1_sleep: spi1_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 10)
+                     NRF_PSEL(SPIM_SCK, 1, 13)
+                     NRF_PSEL(SPIM_MISO, 1, 11)>;
+            low-power-enable;
+        };
+    };
+};
+
 &spi0 {
     compatible = "nordic,nrf-spim";
     /* Cannot be used together with i2c0. */
     status = "okay";
-    mosi-pin = <(32*0+10)>;  // P0_10
-    sck-pin = <(32*1+13)>;  // P1_13
-    miso-pin = <(32*1+11)>;  // P1_11
     cs-gpios = <&pro_micro 10 GPIO_ACTIVE_LOW>;
+    pinctrl-0 = <&spi0_default>;
+    pinctrl-1 = <&spi0_sleep>;
+    pinctrl-names = "default", "sleep";
+
 
     shift_reg: 595@0 {
         compatible = "zmk,gpio-595";
@@ -25,11 +62,11 @@
     compatible = "nordic,nrf-spim";
     /* Cannot be used together with i2c0. */
     status = "okay";
-    mosi-pin = <6>;  // P0_06
-    // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
-    sck-pin = <5>;  // P0_05
-    miso-pin = <7>;  // P0_07
     cs-gpios = <&pro_micro 1 GPIO_ACTIVE_LOW>;
+    pinctrl-0 = <&spi1_default>;
+    pinctrl-1 = <&spi1_sleep>;
+    pinctrl-names = "default", "sleep";
+
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";


### PR DESCRIPTION
New ZMK version changes how I2C and SPI definitions are done - I had to make these changes for my keymap to build properly.